### PR TITLE
Fix server.js API path

### DIFF
--- a/studio/server.js
+++ b/studio/server.js
@@ -2,5 +2,8 @@ const express = require('express');
 const app = express();
 app.use(express.json());
 app.use(express.static('studio'));
-app.use('/api/agent', require('./studio/api/agent'));
+// Serve the API from the local "api" directory. The previous path
+// mistakenly looked for "studio/api" relative to this file, which
+// resulted in a "Cannot find module" error when starting the server.
+app.use('/api/agent', require('./api/agent'));
 app.listen(3000, () => console.log('Studio running on http://localhost:3000'));


### PR DESCRIPTION
## Summary
- adjust the Express route to use the correct relative path

## Testing
- `npm test` *(fails: could not read package.json)*
- `node studio/server.js` *(fails: cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68400202a718832bbfc5ff64252de139